### PR TITLE
Expand CI to include Intel and PGI compilers

### DIFF
--- a/.github/workflows/linux_gnu.yml
+++ b/.github/workflows/linux_gnu.yml
@@ -1,0 +1,50 @@
+name: Linux GNU
+# triggered events (push, pull_request) for the develop branch
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+
+  ubuntu_build:
+    name: Ubuntu GNU Build
+    # Run on ubuntu-latest
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Test debug mode
+      - name: Build crtm debug
+        run: |
+          cd ref
+          rm -rf build
+          mkdir build
+          cd build
+          export OMP_NUM_THREADS=4
+          export CC=gcc
+          export FC=gfortran
+          cmake -DCMAKE_BUILD_TYPE=debug ..
+          make
+          ctest --output-on-failure
+
+      # Test release mode
+      - name: Build crtm release
+        run: |
+          cd ref
+          rm -rf build
+          mkdir build
+          cd build
+          export OMP_NUM_THREADS=4
+          export CC=gcc
+          export FC=gfortran
+          cmake -DCMAKE_BUILD_TYPE=release ..
+          make
+          ctest --output-on-failure

--- a/.github/workflows/linux_intel.yml
+++ b/.github/workflows/linux_intel.yml
@@ -1,0 +1,84 @@
+name: Linux Intel
+# triggered events (push, pull_request) for the develop branch
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+
+  ubuntu_build:
+    name: Ubuntu Intel Build
+    # Run on ubuntu-latest
+    runs-on: ubuntu-latest
+
+    env:
+      LINUX_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/17764/l_HPCKit_p_2021.2.0.2997_offline.sh
+      CC: icc
+      FC: ifort
+      CXX: icpc
+
+    steps:
+      # Cache Intel HPC Toolkit
+      - name: Cache Intel HPC Toolkit
+        id: cache-intel-hpc-toolkit
+        uses: actions/cache@v2
+        with:
+          path: /opt/intel/oneapi
+          key: install-${{ env.LINUX_HPCKIT_URL }}-all
+
+      # Install Intel HPC Toolkit
+      - name: Install Intel HPC Toolkit
+        if: steps.cache-intel-hpc-toolkit.outputs.cache-hit != 'true'
+        run: |
+          curl --output webimage.sh --url "$LINUX_HPCKIT_URL" --retry 5 --retry-delay 5
+          chmod +x webimage.sh
+          ./webimage.sh -x -f webimage_extracted --log extract.log
+          rm -rf webimage.sh
+          WEBIMAGE_NAME=$(ls -1 webimage_extracted/)
+          sudo webimage_extracted/"$WEBIMAGE_NAME"/bootstrapper -s --action install --components=all --eula=accept --continue-with-optional-error=yes --log-dir=.
+          cat /opt/intel/oneapi/logs/installer.install.intel.oneapi.lin.hpckit.*
+          rm -rf webimage_extracted
+
+      # Check location of installed Intel compilers
+      - name: Check compiler install
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          which icc
+          which ifort
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Test debug mode
+      - name: Build crtm debug
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          cd ref
+          rm -rf build
+          mkdir build
+          cd build
+          export OMP_NUM_THREADS=4
+          export CC=icc
+          export FC=ifort
+          cmake -DCMAKE_BUILD_TYPE=debug ..
+          make
+          ctest --output-on-failure
+
+      # Test release mode
+      - name: Build crtm release
+        run: |
+          cd ref
+          rm -rf build
+          mkdir build
+          cd build
+          export OMP_NUM_THREADS=4
+          export CC=icc
+          export FC=ifort
+          cmake -DCMAKE_BUILD_TYPE=release ..
+          make
+          ctest --output-on-failure

--- a/.github/workflows/linux_intel.yml
+++ b/.github/workflows/linux_intel.yml
@@ -72,6 +72,7 @@ jobs:
       # Test release mode
       - name: Build crtm release
         run: |
+          source /opt/intel/oneapi/setvars.sh
           cd ref
           rm -rf build
           mkdir build

--- a/.github/workflows/linux_nvhpc.yml
+++ b/.github/workflows/linux_nvhpc.yml
@@ -1,0 +1,77 @@
+name: Linux NVHPC
+# triggered events (push, pull_request) for the develop branch
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+
+  ubuntu_build:
+    name: Ubuntu NVHPC Build
+    # Run on ubuntu-latest
+    runs-on: ubuntu-latest
+
+    env:
+      NVIDIA_HPC_SDK_URL1: https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc-21-9_21.9_amd64.deb
+      NVIDIA_HPC_SDK_URL2: https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc-2021_21.9_amd64.deb
+      CC: nvc
+      FC: nvfortran
+      CXX: nvc
+
+    steps:
+      # Cache NVHPC SDK
+      - name: Cache NVIDIA HPC SDK
+        id: cache-nvchpc-sdk
+        uses: actions/cache@v2
+        with:
+          path: /opt/nvhpc
+          key: install-${{ env.NVIDIA_HPC_SDK_URL1 }}-${{ env.NVIDIA_HPC_SDK_URL2 }}-all
+
+      # Install NVIDIA HPC SDK
+      - name: Install NVIDIA HPC SDK
+        if: steps.cache-intel-hpc-toolkit.outputs.cache-hit != 'true'
+        run: |
+          wget "$NVIDIA_HPC_SDK_URL1" "$NVIDIA_HPC_SDK_URL2"
+          apt-get install ./nvhpc-21-9_21.9_amd64.deb ./nvhpc-2021_21.9_amd64.deb
+
+      # Check location of installed NVHPC compilers
+      - name: Check compiler install
+        run: |
+          which nvc
+          which nvfortran
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Test debug mode
+      - name: Build crtm debug
+        run: |
+          cd ref
+          rm -rf build
+          mkdir build
+          cd build
+          export OMP_NUM_THREADS=4
+          export CC=nvc
+          export FC=nvfortran
+          cmake -DCMAKE_BUILD_TYPE=debug ..
+          make
+          ctest --output-on-failure
+
+      # Test release mode
+      - name: Build crtm release
+        run: |
+          cd ref
+          rm -rf build
+          mkdir build
+          cd build
+          export OMP_NUM_THREADS=4
+          export CC=nvc
+          export FC=nvfortran
+          cmake -DCMAKE_BUILD_TYPE=release ..
+          make
+          ctest --output-on-failure

--- a/.github/workflows/linux_nvhpc.yml
+++ b/.github/workflows/linux_nvhpc.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Debug install
         run: |
           ls -l /opt
-          ls -l /
+          ls -l /opt/nvidia
+          ls -l /opt/nvidia/nvhpc
 
       # Check location of installed NVHPC compilers
       - name: Check compiler install

--- a/.github/workflows/linux_nvhpc.yml
+++ b/.github/workflows/linux_nvhpc.yml
@@ -18,9 +18,6 @@ jobs:
     env:
       NVIDIA_HPC_SDK_URL1: https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc-21-9_21.9_amd64.deb
       NVIDIA_HPC_SDK_URL2: https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc-2021_21.9_amd64.deb
-      CC: nvc
-      FC: nvfortran
-      CXX: nvc
 
     steps:
 
@@ -42,7 +39,7 @@ jobs:
 
       # Install NVIDIA HPC SDK
       - name: Install NVIDIA HPC SDK
-        if: steps.cache-intel-hpc-toolkit.outputs.cache-hit != 'true'
+        if: steps.cache-nvchpc-sdk.outputs.cache-hit != 'true'
         run: |
           wget "$NVIDIA_HPC_SDK_URL1" "$NVIDIA_HPC_SDK_URL2"
           sudo apt-get install ./nvhpc-21-9_21.9_amd64.deb ./nvhpc-2021_21.9_amd64.deb
@@ -57,6 +54,7 @@ jobs:
       # Check location of installed NVHPC compilers
       - name: Check compiler install
         run: |
+          source /usr/share/lmod/lmod/init/bash
           module use /opt/nvidia/hpc_sdk/modulefiles
           module av
           module load nvhpc
@@ -70,13 +68,13 @@ jobs:
       # Test debug mode
       - name: Build crtm debug
         run: |
+          source /usr/share/lmod/lmod/init/bash
           cd ref
           rm -rf build
           mkdir build
           cd build
           export OMP_NUM_THREADS=4
-          export CC=nvc
-          export FC=nvfortran
+          module load nvhpc
           cmake -DCMAKE_BUILD_TYPE=debug ..
           make
           ctest --output-on-failure
@@ -84,13 +82,13 @@ jobs:
       # Test release mode
       - name: Build crtm release
         run: |
+          source /usr/share/lmod/lmod/init/bash
           cd ref
           rm -rf build
           mkdir build
           cd build
           export OMP_NUM_THREADS=4
-          export CC=nvc
-          export FC=nvfortran
+          module load nvhpc
           cmake -DCMAKE_BUILD_TYPE=release ..
           make
           ctest --output-on-failure

--- a/.github/workflows/linux_nvhpc.yml
+++ b/.github/workflows/linux_nvhpc.yml
@@ -7,6 +7,10 @@ on:
     branches: [ develop ]
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
 
@@ -26,20 +30,20 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install lmod
-          source /usr/share/lmod/lmod/init/bash
+#          echo "source /usr/share/lmod/lmod/init/bash" >> ~/.bash_profile
           module list
 
       # Cache NVHPC SDK
       - name: Cache NVIDIA HPC SDK
-        id: cache-nvchpc-sdk
+        id: cache-nvhpc-sdk
         uses: actions/cache@v2
         with:
-          path: /opt/nvidia/hpc_sdk
+          path: /opt/nvidia
           key: install-${{ env.NVIDIA_HPC_SDK_URL1 }}-${{ env.NVIDIA_HPC_SDK_URL2 }}-all
 
       # Install NVIDIA HPC SDK
       - name: Install NVIDIA HPC SDK
-        if: steps.cache-nvchpc-sdk.outputs.cache-hit != 'true'
+        if: steps.cache-nvhpc-sdk.outputs.cache-hit != 'true'
         run: |
           wget "$NVIDIA_HPC_SDK_URL1" "$NVIDIA_HPC_SDK_URL2"
           sudo apt-get install ./nvhpc-21-9_21.9_amd64.deb ./nvhpc-2021_21.9_amd64.deb

--- a/.github/workflows/linux_nvhpc.yml
+++ b/.github/workflows/linux_nvhpc.yml
@@ -30,7 +30,6 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install lmod
-#          echo "source /usr/share/lmod/lmod/init/bash" >> ~/.bash_profile
           module list
 
       # Cache NVHPC SDK

--- a/.github/workflows/linux_nvhpc.yml
+++ b/.github/workflows/linux_nvhpc.yml
@@ -38,6 +38,12 @@ jobs:
           wget "$NVIDIA_HPC_SDK_URL1" "$NVIDIA_HPC_SDK_URL2"
           sudo apt-get install ./nvhpc-21-9_21.9_amd64.deb ./nvhpc-2021_21.9_amd64.deb
 
+      # Debug install
+      - name: Debug install
+        run: |
+          ls -l /opt
+          ls -l /
+
       # Check location of installed NVHPC compilers
       - name: Check compiler install
         run: |

--- a/.github/workflows/linux_nvhpc.yml
+++ b/.github/workflows/linux_nvhpc.yml
@@ -34,17 +34,8 @@ jobs:
           source /usr/share/lmod/lmod/init/bash
           module list
 
-      # Cache NVHPC SDK
-      - name: Cache NVIDIA HPC SDK
-        id: cache-nvhpc-sdk
-        uses: actions/cache@v2
-        with:
-          path: /opt/nvidia
-          key: install-${{ env.NVIDIA_HPC_SDK_URL1 }}-${{ env.NVIDIA_HPC_SDK_URL2 }}-all
-
       # Install NVIDIA HPC SDK
       - name: Install NVIDIA HPC SDK
-        if: steps.cache-nvhpc-sdk.outputs.cache-hit != 'true'
         run: |
           wget "$NVIDIA_HPC_SDK_URL1" "$NVIDIA_HPC_SDK_URL2"
           sudo apt-get install ./nvhpc-21-9_21.9_amd64.deb ./nvhpc-2021_21.9_amd64.deb

--- a/.github/workflows/linux_nvhpc.yml
+++ b/.github/workflows/linux_nvhpc.yml
@@ -23,6 +23,13 @@ jobs:
       CXX: nvc
 
     steps:
+
+      # Install Lmod
+      - name: Install Lmod
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install lmod
+
       # Cache NVHPC SDK
       - name: Cache NVIDIA HPC SDK
         id: cache-nvchpc-sdk
@@ -48,6 +55,9 @@ jobs:
       # Check location of installed NVHPC compilers
       - name: Check compiler install
         run: |
+          module use /opt/nvidia/hpc_sdk/modulefiles
+          module av
+          module load nvhpc
           which nvc
           which nvfortran
 

--- a/.github/workflows/linux_nvhpc.yml
+++ b/.github/workflows/linux_nvhpc.yml
@@ -29,6 +29,8 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install lmod
+          source /usr/share/lmod/lmod/init/bash
+          module list
 
       # Cache NVHPC SDK
       - name: Cache NVIDIA HPC SDK

--- a/.github/workflows/linux_nvhpc.yml
+++ b/.github/workflows/linux_nvhpc.yml
@@ -28,7 +28,7 @@ jobs:
         id: cache-nvchpc-sdk
         uses: actions/cache@v2
         with:
-          path: /opt/nvhpc
+          path: /opt/nvidia/hpc_sdk
           key: install-${{ env.NVIDIA_HPC_SDK_URL1 }}-${{ env.NVIDIA_HPC_SDK_URL2 }}-all
 
       # Install NVIDIA HPC SDK
@@ -43,7 +43,7 @@ jobs:
         run: |
           ls -l /opt
           ls -l /opt/nvidia
-          ls -l /opt/nvidia/nvhpc
+          ls -l /opt/nvidia/hpc_sdk
 
       # Check location of installed NVHPC compilers
       - name: Check compiler install

--- a/.github/workflows/linux_nvhpc.yml
+++ b/.github/workflows/linux_nvhpc.yml
@@ -36,7 +36,7 @@ jobs:
         if: steps.cache-intel-hpc-toolkit.outputs.cache-hit != 'true'
         run: |
           wget "$NVIDIA_HPC_SDK_URL1" "$NVIDIA_HPC_SDK_URL2"
-          apt-get install ./nvhpc-21-9_21.9_amd64.deb ./nvhpc-2021_21.9_amd64.deb
+          sudo apt-get install ./nvhpc-21-9_21.9_amd64.deb ./nvhpc-2021_21.9_amd64.deb
 
       # Check location of installed NVHPC compilers
       - name: Check compiler install

--- a/.github/workflows/linux_nvhpc.yml
+++ b/.github/workflows/linux_nvhpc.yml
@@ -54,7 +54,6 @@ jobs:
         run: |
           source /usr/share/lmod/lmod/init/bash
           module use /opt/nvidia/hpc_sdk/modulefiles
-          module av
           module load nvhpc
           which nvc
           which nvfortran
@@ -67,12 +66,13 @@ jobs:
       - name: Build crtm debug
         run: |
           source /usr/share/lmod/lmod/init/bash
+          module use /opt/nvidia/hpc_sdk/modulefiles
+          module load nvhpc
           cd ref
           rm -rf build
           mkdir build
           cd build
           export OMP_NUM_THREADS=4
-          module load nvhpc
           cmake -DCMAKE_BUILD_TYPE=debug ..
           make
           ctest --output-on-failure
@@ -81,12 +81,13 @@ jobs:
       - name: Build crtm release
         run: |
           source /usr/share/lmod/lmod/init/bash
+          module use /opt/nvidia/hpc_sdk/modulefiles
+          module load nvhpc
           cd ref
           rm -rf build
           mkdir build
           cd build
           export OMP_NUM_THREADS=4
-          module load nvhpc
           cmake -DCMAKE_BUILD_TYPE=release ..
           make
           ctest --output-on-failure

--- a/.github/workflows/linux_nvhpc.yml
+++ b/.github/workflows/linux_nvhpc.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install lmod
+          echo "source /usr/share/lmod/lmod/init/bash" >> ~/.bash_profile
+          source /usr/share/lmod/lmod/init/bash
           module list
 
       # Cache NVHPC SDK
@@ -46,13 +48,6 @@ jobs:
         run: |
           wget "$NVIDIA_HPC_SDK_URL1" "$NVIDIA_HPC_SDK_URL2"
           sudo apt-get install ./nvhpc-21-9_21.9_amd64.deb ./nvhpc-2021_21.9_amd64.deb
-
-      # Debug install
-      - name: Debug install
-        run: |
-          ls -l /opt
-          ls -l /opt/nvidia
-          ls -l /opt/nvidia/hpc_sdk
 
       # Check location of installed NVHPC compilers
       - name: Check compiler install

--- a/.github/workflows/macos_gnu.yml
+++ b/.github/workflows/macos_gnu.yml
@@ -1,4 +1,4 @@
-name: CI for crtm
+name: MacOS GNU
 # triggered events (push, pull_request) for the develop branch
 on:
   push:
@@ -8,11 +8,10 @@ on:
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
-# This workflow contains multiple jobs for different operating systems
 jobs:
 
   macos_Build:
-    name: Mac OS Build
+    name: Mac OS GNU Build
     # The type of runner that the job will run on
     runs-on: macos-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -49,45 +48,6 @@ jobs:
           export OMP_NUM_THREADS=4
           export CC=gcc-10
           export FC=gfortran-10           
-          cmake -DCMAKE_BUILD_TYPE=release ..
-          make
-          ctest --output-on-failure
-
-  ubuntu_build:
-    name: Ubuntu Build
-    # Run on ubuntu-latest
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      # Test debug mode
-      - name: Build crtm debug
-        run: |
-          cd ref
-          rm -rf build
-          mkdir build
-          cd build
-          export OMP_NUM_THREADS=4
-          export CC=gcc
-          export FC=gfortran
-          cmake -DCMAKE_BUILD_TYPE=debug ..
-          make
-          ctest --output-on-failure
-
-      # Test release mode
-      - name: Build crtm release
-        run: |
-          cd ref
-          rm -rf build
-          mkdir build
-          cd build
-          export OMP_NUM_THREADS=4
-          export CC=gcc
-          export FC=gfortran
           cmake -DCMAKE_BUILD_TYPE=release ..
           make
           ctest --output-on-failure

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -1,0 +1,87 @@
+name: MacOS Intel
+# triggered events (push, pull_request) for the develop branch
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+
+  macos_Build:
+    name: Mac OS Intel Build
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+
+    env:
+      MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/17643/m_HPCKit_p_2021.2.0.2903_offline.dmg
+      CC: icc
+      FC: ifort
+      CXX: icpc
+
+    steps:
+      # Prepare for Intel cache restore
+      - name: Prepare for Intel cache restore
+        run: |
+          sudo mkdir -p /opt/intel
+          sudo chown $USER /opt/intel
+      # Cache Intel HPC Toolkit
+      - name: Cache Intel HPC Toolkit
+        id: cache-intel-hpc-toolkit
+        uses: actions/cache@v2
+        with:
+          path: /opt/intel/oneapi
+          key: install-${{ env.MACOS_HPCKIT_URL }}-all
+
+      # Install Intel HPC Toolkit
+      - name: Install Intel HPC Toolkit
+        if: steps.cache-intel-hpc-toolkit.outputs.cache-hit != 'true'
+        run: |
+          curl --output webimage.dmg --url "$MACOS_HPCKIT_URL" --retry 5 --retry-delay 5
+          hdiutil attach webimage.dmg
+          sudo /Volumes/$(basename $MACOS_HPCKIT_URL .dmg)/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --components=all --eula=accept --continue-with-optional-error=yes --log-dir=.
+          cat /opt/intel/oneapi/logs/installer.install.intel.oneapi.mac.hpckit.*
+          hdiutil detach /Volumes/$(basename "$MACOS_HPCKIT_URL" .dmg) -quiet
+
+      # Check location of installed Intel compilers
+      - name: Check compiler install
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          which icc
+          which ifort
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
+      # Test debug mode 
+      - name: Test crtm Debug 
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          cd ref
+          rm -rf build
+          mkdir build
+          cd build
+          export OMP_NUM_THREADS=4
+          export CC=icc
+          export FC=ifort
+          cmake -DCMAKE_BUILD_TYPE=debug ..
+          make
+          ctest --output-on-failure
+          
+      # Test release mode 
+      - name: Test crtm Release
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          cd ref
+          rm -rf build
+          mkdir build
+          cd build
+          export OMP_NUM_THREADS=4
+          export CC=icc
+          export FC=ifort
+          cmake -DCMAKE_BUILD_TYPE=release ..
+          make
+          ctest --output-on-failure

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![CI for crtm](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/ci.yml/badge.svg)](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/ci.yml)
+[![Linux GNU](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/linux_gnu.yml/badge.svg)](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/linux_gnu.yml)
+[![Linux Intel](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/linux_intel.yml/badge.svg)](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/linux_intel.yml)
+[![Linux NVHPC](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/linux_nvhpc.yml/badge.svg)](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/linux_nvhpc.yml)
+[![MacOS GNU](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/macos_gnu.yml/badge.svg)](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/macos_gnu.yml)
+[![MacOS Intel](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/macos_intel.yml/badge.svg)](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/macos_intel.yml)
 
 ```
 This repository is a scientific product and is not official communication


### PR DESCRIPTION
This PR splits the CI workflow configuration into separate files for each compiler/OS to simplify understanding of each workflow. It also adds CI configuration for the Intel and PGI compilers.