### PR TITLE
Add workflow for testing on self-hosted GPU runner on AWS

### DIFF
--- a/.github/workflows/gpu_nvhpc.yml
+++ b/.github/workflows/gpu_nvhpc.yml
@@ -1,0 +1,53 @@
+name: Linux GPU NVHPC
+# triggered events (push, pull_request) for the develop branch
+on:
+  pull_request:
+    branches: [ develop ]
+    types: [ labeled ]
+  workflow_dispatch:
+
+#defaults:
+#  run:
+#    shell: bash -leo pipefail {0}
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+
+  GPU_build:
+    if: ${{ github.event.label.name == 'GPU_Test' }}
+
+    name: GPU Build
+    # Run on self-hosted
+    runs-on: self-hosted
+
+    steps:
+
+      # Load NVHPC module
+      - name: Load NVHPC Module
+        run: |
+          pwd
+          ls -al
+          echo $SHELL
+          module use /opt/nvidia/hpc_sdk/modulefiles
+          module load nvhpc
+          which nvc
+          which nvfortran
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Test release mode
+      - name: Build crtm release
+        run: |
+          source /usr/share/lmod/lmod/init/bash
+          module use /opt/nvidia/hpc_sdk/modulefiles
+          module load nvhpc
+          cd ref
+          rm -rf build
+          mkdir build
+          cd build
+          export OMP_NUM_THREADS=4
+          cmake -DCMAKE_BUILD_TYPE=release -DENABLE_GPU=on ..
+          make
+          ctest --output-on-failure -R gpu_kernel

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Linux NVHPC](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/linux_nvhpc.yml/badge.svg)](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/linux_nvhpc.yml)
 [![MacOS GNU](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/macos_gnu.yml/badge.svg)](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/macos_gnu.yml)
 [![MacOS Intel](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/macos_intel.yml/badge.svg)](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/macos_intel.yml)
+[![Linux GPU NVHPC](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/gpu_nvhpc.yml/badge.svg)](https://github.com/NOAA-GSL/SENA-crtm/actions/workflows/gpu_nvhpc.yml)
 
 ```
 This repository is a scientific product and is not official communication


### PR DESCRIPTION
This PR adds a workflow that uses a self-hosted runner for testing on GPUs.  The self-hosted runner is a AWS EC2 p3.2xlarge instance with a V100 GPU and must currently be started/stopped manually by an admin.  Additionally, the workflow can only be triggered by an admin adding the "GPU_Test" label to a given PR.  Automation to start/stop the self-hosted runner EC2 instance can be added at a later time.